### PR TITLE
Add API callback prop

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -24,5 +24,6 @@ module.exports = {
     'react/require-default-props': 'off',
     'no-use-before-define': 'off',
     'react/jsx-filename-extension': [1, { extensions: ['.ts', '.tsx'] }],
+    'no-unused-vars': ['error', { argsIgnorePattern: 'api' }],
   },
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,11 +8,12 @@ interface Props {
   width?: number
   height?: number
   contained?: boolean;
-  config?: Config
+  config?: Config;
+  onApiReady?: (api: Api) => void;
 }
 
 function Chessground({
-  width = 900, height = 900, config = {}, contained = false,
+  width = 900, height = 900, config = {}, contained = false, onApiReady,
 }: Props) {
   const [api, setApi] = useState<Api | null>(null);
 
@@ -33,6 +34,12 @@ function Chessground({
   useEffect(() => {
     api?.set(config);
   }, [api, config]);
+
+  useEffect(() => {
+    if (api && onApiReady) {
+      onApiReady(api);
+    }
+  }, [api]);
 
   return (
     <div style={{ height: contained ? '100%' : height, width: contained ? '100%' : width }}>


### PR DESCRIPTION
The current React component doesn't expose the Chessground API in it's interface, which makes it difficult to interact directly with the board from other components.

I've surfaced the API in a callback props called `onApiReady`. This makes the Chessground API available to calling code, and allows interactions like making a move on the board, resetting the board to a new position, and adding arrows. API interface documentation here:  https://github.com/lichess-org/chessground/blob/master/src/api.ts

Sample code demonstrating its use:

```typescript
import Chessground from "@react-chess/chessground"
import { Config } from 'chessground/config'
import { Api } from 'chessground/api'
import { Key } from 'chessground/types'

const CONFIG: Config = {
  fen: "rnbq1rk1/1p3pbp/p2p1np1/2pP4/P3P3/2NB4/1P2NPPP/R1BQ1RK1 b - a3 0 10",
  lastMove: ["a2", "a4"],
  turnColor: "black",
  movable: {
    free: false
  }
}

const MOVES = "d8c7 e2g3 b8d7 h2h3 c5c4 d3c2 a8b8 c1e3 d7c5 a4a5 c8d7 d1d2 b7b5".split(" ")

export const BasicMovesView = () => {

  const onApiReadyHandler = (api: Api) => {
    const interval = setInterval(() => {
      const move: string = MOVES.shift() as string
      if (move) {
        api.move(move.substring(0, 2) as Key, move.substring(2,4) as Key)
      } else {
        clearInterval(interval)
      }
    }, 2000)
  }

  return (
    <Chessground width={640} height={640} config={CONFIG} onApiReady={onApiReadyHandler} />
  )
}
```
